### PR TITLE
대출 심사 삭제 api 구현

### DIFF
--- a/src/main/java/com/example/loan/controller/JudgmentController.java
+++ b/src/main/java/com/example/loan/controller/JudgmentController.java
@@ -37,4 +37,10 @@ public class JudgmentController extends AbstractController {
         return ok(judgmentService.updateJudgment(judgmentId, request));
     }
 
+    @DeleteMapping("/{judgmentId}")
+    public ResponseDTO<Void> deleteJudgment(@PathVariable Long judgmentId) {
+        judgmentService.deleteJudgment(judgmentId);
+        return ok();
+    }
+
 }

--- a/src/main/java/com/example/loan/service/JudgmentService.java
+++ b/src/main/java/com/example/loan/service/JudgmentService.java
@@ -11,4 +11,6 @@ public interface JudgmentService {
     JudgmentDTO.Response getJudgmentOfApplication(Long applicationId);
 
     JudgmentDTO.Response updateJudgment(Long judgmentId, JudgmentDTO.Request request);
+
+    void deleteJudgment(Long judgmentId);
 }

--- a/src/main/java/com/example/loan/service/JudgmentServiceImpl.java
+++ b/src/main/java/com/example/loan/service/JudgmentServiceImpl.java
@@ -81,11 +81,21 @@ public class JudgmentServiceImpl implements JudgmentService {
         return modelMapper.map(judgment, JudgmentDTO.Response.class);
     }
 
+    /**
+     * 대출 심사 삭제
+     */
+    @Override
+    public void deleteJudgment(Long judgmentId) {
+        Judgment judgment = judgmentRepository.findById(judgmentId)
+                .orElseThrow(() -> new BaseException(ResultType.NOT_FOUND_JUDGMENT));
+
+        judgment.setIsDeleted(true);
+
+        judgmentRepository.save(judgment);
+    }
 
 
     private boolean isPresentApplication(Long applicationId) {
         return applicationRepository.findById(applicationId).isPresent();
     }
-
-
 }

--- a/src/test/java/com/example/loan/service/JudgmentServiceTest.java
+++ b/src/test/java/com/example/loan/service/JudgmentServiceTest.java
@@ -142,5 +142,25 @@ public class JudgmentServiceTest {
         assertThat(response.getApprovalAmount()).isEqualTo(request.getApprovalAmount());
     }
 
+    @Test
+    @DisplayName("대출 심사 삭제 서비스")
+    void Should_DeletedJudgmentEntity_When_RequestDeleteExistJudgmentInfo() {
+        //given
+        Judgment judgment = Judgment.builder()
+                .judgmentId(1L)
+                .build();
+
+        when(judgmentRepository.findById(1L))
+                .thenReturn(Optional.of(judgment));
+
+        when(judgmentRepository.save(ArgumentMatchers.any(Judgment.class)))
+                .thenReturn(judgment);
+
+        //when
+        judgmentService.deleteJudgment(1L);
+
+        //then
+        assertThat(judgment.getIsDeleted()).isTrue();
+    }
 
 }


### PR DESCRIPTION
## 작업 내용 (Contents)
<!-- 이 PR에서 어떤 점들이 변경되었는지 기술해주세요.-->
- 대출 심사 삭제 api 구현
- **soft delete 방식을 사용하고 있기 때문에, 해당 심사 아이디로 요청이 들어오면 is_deleted 값을 true 로 업데이트 해주는 방식으로 구현 진행**
- 대출 심사 삭제 서비스 테스트 코드 작성
<br>

## 기타 사항 (Etc)
<!-- PR 에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등 -->
- 

<br>

## 테스트 (Test)
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요. -->
- [x] 대출 심사 삭제 서비스 테스트 코드
