### PR TITLE
대출 심사 승인 금액 부여 api 구현

### DIFF
--- a/src/main/java/com/example/loan/controller/JudgmentController.java
+++ b/src/main/java/com/example/loan/controller/JudgmentController.java
@@ -1,5 +1,6 @@
 package com.example.loan.controller;
 
+import com.example.loan.dto.ApplicationDTO;
 import com.example.loan.dto.JudgmentDTO;
 import com.example.loan.dto.ResponseDTO;
 import com.example.loan.service.JudgmentService;
@@ -41,6 +42,12 @@ public class JudgmentController extends AbstractController {
     public ResponseDTO<Void> deleteJudgment(@PathVariable Long judgmentId) {
         judgmentService.deleteJudgment(judgmentId);
         return ok();
+    }
+
+    @PatchMapping("/{judgmentId}/grants")
+    public ResponseDTO<ApplicationDTO.GrantAmount> grant(
+            @PathVariable Long judgmentId) {
+        return ok(judgmentService.grant(judgmentId));
     }
 
 }

--- a/src/main/java/com/example/loan/domain/Application.java
+++ b/src/main/java/com/example/loan/domain/Application.java
@@ -43,6 +43,9 @@ public class Application extends BaseEntity {
     @Column(columnDefinition = "decimal(15,2) DEFAULT NULL COMMENT '대출 신청 금액'")
     private BigDecimal hopeAmount;
 
+    @Column(columnDefinition = "decimal(15,2) DEFAULT NULL COMMENT '대출 승인 금액'")
+    private BigDecimal approvalAmount;
+
     @Column(columnDefinition = "datetime DEFAULT NULL COMMENT '만기일'")
     private LocalDateTime maturity;
 

--- a/src/main/java/com/example/loan/dto/ApplicationDTO.java
+++ b/src/main/java/com/example/loan/dto/ApplicationDTO.java
@@ -54,4 +54,19 @@ public class ApplicationDTO implements Serializable {
     public static class AcceptTerms {
         List<Long> acceptTermsIds;
     }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GrantAmount {
+        private Long applicationId;
+
+        private BigDecimal approvalAmount;
+
+        private LocalDateTime createdAt;
+
+        private LocalDateTime updatedAt;
+    }
 }

--- a/src/main/java/com/example/loan/service/JudgmentService.java
+++ b/src/main/java/com/example/loan/service/JudgmentService.java
@@ -1,5 +1,6 @@
 package com.example.loan.service;
 
+import com.example.loan.dto.ApplicationDTO;
 import com.example.loan.dto.JudgmentDTO;
 
 public interface JudgmentService {
@@ -13,4 +14,6 @@ public interface JudgmentService {
     JudgmentDTO.Response updateJudgment(Long judgmentId, JudgmentDTO.Request request);
 
     void deleteJudgment(Long judgmentId);
+
+    ApplicationDTO.GrantAmount grant(Long judgmentId);
 }

--- a/src/main/java/com/example/loan/service/JudgmentServiceImpl.java
+++ b/src/main/java/com/example/loan/service/JudgmentServiceImpl.java
@@ -1,6 +1,8 @@
 package com.example.loan.service;
 
+import com.example.loan.domain.Application;
 import com.example.loan.domain.Judgment;
+import com.example.loan.dto.ApplicationDTO;
 import com.example.loan.dto.JudgmentDTO;
 import com.example.loan.exception.BaseException;
 import com.example.loan.exception.ResultType;
@@ -9,6 +11,8 @@ import com.example.loan.repository.JudgmentRepository;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
 
 @Service
 @RequiredArgsConstructor
@@ -92,6 +96,26 @@ public class JudgmentServiceImpl implements JudgmentService {
         judgment.setIsDeleted(true);
 
         judgmentRepository.save(judgment);
+    }
+
+    /**
+     * 대출 심사 승인 금액 부여
+     */
+    @Override
+    public ApplicationDTO.GrantAmount grant(Long judgmentId) {
+        Judgment judgment = judgmentRepository.findById(judgmentId)
+                .orElseThrow(() -> new BaseException(ResultType.NOT_FOUND_JUDGMENT));
+
+        Long applicationId = judgment.getApplicationId();
+        Application application = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new BaseException(ResultType.NOT_FOUND_APPLICATION));
+
+        BigDecimal approvalAmount = judgment.getApprovalAmount();
+        application.setApprovalAmount(approvalAmount);
+
+        applicationRepository.save(application);
+
+        return modelMapper.map(application, ApplicationDTO.GrantAmount.class);
     }
 
 

--- a/src/test/java/com/example/loan/service/JudgmentServiceTest.java
+++ b/src/test/java/com/example/loan/service/JudgmentServiceTest.java
@@ -2,6 +2,7 @@ package com.example.loan.service;
 
 import com.example.loan.domain.Application;
 import com.example.loan.domain.Judgment;
+import com.example.loan.dto.ApplicationDTO;
 import com.example.loan.dto.JudgmentDTO;
 import com.example.loan.repository.ApplicationRepository;
 import com.example.loan.repository.JudgmentRepository;
@@ -161,6 +162,39 @@ public class JudgmentServiceTest {
 
         //then
         assertThat(judgment.getIsDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("대출 심사 승인 금액 부여")
+    void Should_ReturnUpdateResponseOfExistApplicationEntity_When_RequestGrantAmountOfJudgmentInfo() {
+        //given
+        Judgment judgment = Judgment.builder()
+                .name("Member Yu")
+                .judgmentId(1L)
+                .applicationId(1L)
+                .approvalAmount(BigDecimal.valueOf(8000000))
+                .build();
+
+        Application application = Application.builder()
+                .applicationId(1L)
+                .approvalAmount(BigDecimal.valueOf(8000000))
+                .build();
+
+        when(judgmentRepository.findById(1L))
+                .thenReturn(Optional.of(judgment));
+
+        when(applicationRepository.findById(1L))
+                .thenReturn(Optional.of(application));
+
+        when(applicationRepository.save(ArgumentMatchers.any(Application.class)))
+                .thenReturn(application);
+
+        //when
+        ApplicationDTO.GrantAmount response = judgmentService.grant(1L);
+
+        //then
+        assertThat(response.getApplicationId()).isEqualTo(1L);
+        assertThat(response.getApprovalAmount()).isEqualTo(judgment.getApprovalAmount());
     }
 
 }


### PR DESCRIPTION
## 작업 내용 (Contents)
<!-- 이 PR에서 어떤 점들이 변경되었는지 기술해주세요.-->
- 대출 심사 승인 금액 부여 api 구현
- 대출 심사를 통해 승인된 금액을 처리하는 기능 
- **승인 금액을 부여하면, 대출 신청 아이디에 승인 금액이 업데이트 되도록 구현**
- 대출 심사 승인 금액 부여 서비스 테스트 코드 작성

<br>

## 기타 사항 (Etc)
<!-- PR 에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등 -->
- 대출 심사 승인 금액부여를 진행할 때, 대출 심사 아이디와 대출 신청 내역이 존재하지 않는 경우 에러 발생시킴

<br>

## 테스트 (Test)
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요. -->
- [x]  대출 심사 승인 금액 부여 서비스 테스트 코드
