### PR TITLE
대출 집행&잔고 도메인 테이블 정의

### DIFF
--- a/src/main/java/com/example/loan/domain/Balance.java
+++ b/src/main/java/com/example/loan/domain/Balance.java
@@ -1,0 +1,31 @@
+package com.example.loan.domain;
+
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+@Where(clause = "is_deleted=false")
+public class Balance extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long balanceId;
+
+    @Column(columnDefinition = "bigint NOT NULL COMMENT '신청 ID'")
+    private Long applicationId;
+
+    @Column(columnDefinition = "decimal(15,2) NOT NULL COMMENT '잔여 대출 금액'")
+    private BigDecimal balance;
+}

--- a/src/main/java/com/example/loan/domain/Entry.java
+++ b/src/main/java/com/example/loan/domain/Entry.java
@@ -1,0 +1,31 @@
+package com.example.loan.domain;
+
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+@Where(clause = "is_deleted=false")
+public class Entry extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long entryId;
+
+    @Column(columnDefinition = "bigint NOT NULL COMMENT '신청 ID'")
+    private Long applicationId;
+
+    @Column(columnDefinition = "decimal(15,2) NOT NULL COMMENT '집행 금액'")
+    private BigDecimal entryAmount;
+}

--- a/src/main/java/com/example/loan/repository/BalanceRepository.java
+++ b/src/main/java/com/example/loan/repository/BalanceRepository.java
@@ -1,0 +1,9 @@
+package com.example.loan.repository;
+
+import com.example.loan.domain.Balance;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BalanceRepository extends JpaRepository<Balance, Long> {
+}

--- a/src/main/java/com/example/loan/repository/EntryRepository.java
+++ b/src/main/java/com/example/loan/repository/EntryRepository.java
@@ -1,0 +1,9 @@
+package com.example.loan.repository;
+
+import com.example.loan.domain.Entry;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EntryRepository extends JpaRepository<Entry, Long> {
+}


### PR DESCRIPTION
## 작업 내용 (Contents)
<!-- 이 PR에서 어떤 점들이 변경되었는지 기술해주세요.-->
- Entry Entity 생성
- Balance Entity 생성
- **대출 잔고 테이블은 다음 사항이 발생하는 경우에 해당 데이터가 저장되어야 한다.**
      1. 대출금을 집행했을 때, 잔여 대출 금액(balance) 가 업데이트 되어야 한다.
      2. 차주가 N회차에 거쳐서 대출금을 상환했을 때, 잔여 대출 금액(balance) 가 업데이트 되어야 한다.

<br>

## 기타 사항 (Etc)
<!-- PR 에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등 -->
<figure class="half">
  <a href="link"><img src="https://github.com/hyeonju0121/loan-service-project/assets/67223214/7d8eb8dd-e440-4d2e-afef-b17b404409a0"></a>
  <a href="link"><img src="https://github.com/hyeonju0121/loan-service-project/assets/67223214/08a1c668-7ed1-429a-a5c1-4f2b8996861e"></a>
  <figcaption></figcaption>
</figure>

<br>

## 테스트 (Test)
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요. -->
