### PR TITLE
대출 집행 정보 조회, 수정, 삭제 api 구현

### DIFF
--- a/src/main/java/com/example/loan/controller/InternalController.java
+++ b/src/main/java/com/example/loan/controller/InternalController.java
@@ -21,4 +21,12 @@ public class InternalController extends AbstractController {
             @PathVariable Long applicationId, @RequestBody EntryDTO.Request request) {
         return ok(entryService.create(applicationId, request));
     }
+
+    /**
+     * 대출 집행 조회
+     */
+    @GetMapping("/{applicationId}/entries")
+    public ResponseDTO<EntryDTO.Response> getEntry(@PathVariable Long applicationId) {
+        return ok(entryService.getEntry(applicationId));
+    }
 }

--- a/src/main/java/com/example/loan/controller/InternalController.java
+++ b/src/main/java/com/example/loan/controller/InternalController.java
@@ -29,4 +29,13 @@ public class InternalController extends AbstractController {
     public ResponseDTO<EntryDTO.Response> getEntry(@PathVariable Long applicationId) {
         return ok(entryService.getEntry(applicationId));
     }
+
+    /**
+     * 대출 집행 수정
+     */
+    @PutMapping("/entries/{entryId}")
+    public ResponseDTO<EntryDTO.UpdateResponse> updateEntry(
+            @PathVariable Long entryId, @RequestBody EntryDTO.Request request) {
+        return ok(entryService.updateEntry(entryId, request));
+    }
 }

--- a/src/main/java/com/example/loan/controller/InternalController.java
+++ b/src/main/java/com/example/loan/controller/InternalController.java
@@ -38,4 +38,13 @@ public class InternalController extends AbstractController {
             @PathVariable Long entryId, @RequestBody EntryDTO.Request request) {
         return ok(entryService.updateEntry(entryId, request));
     }
+
+    /**
+     * 대출 집행 삭제
+     */
+    @DeleteMapping("/entries/{entryId}")
+    public ResponseDTO<Void> deleteEntry (@PathVariable Long entryId) {
+        entryService.deleteEntry(entryId);
+        return ok();
+    }
 }

--- a/src/main/java/com/example/loan/dto/BalanceDTO.java
+++ b/src/main/java/com/example/loan/dto/BalanceDTO.java
@@ -25,6 +25,21 @@ public class BalanceDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class UpdateRequest {
+
+        private Long applicationId;
+
+        private BigDecimal beforeEntryAmount;
+
+        private BigDecimal afterEntryAmount;
+
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Response {
 
         private Long balanceId;

--- a/src/main/java/com/example/loan/dto/EntryDTO.java
+++ b/src/main/java/com/example/loan/dto/EntryDTO.java
@@ -35,4 +35,22 @@ public class EntryDTO implements Serializable {
 
         private LocalDateTime updatedAt;
     }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateResponse {
+
+        private Long entryId;
+
+        private Long applicationId;
+
+        private BigDecimal beforeEntryAmount;
+
+        private BigDecimal afterEntryAmount;
+
+        private LocalDateTime updatedAt;
+    }
 }

--- a/src/main/java/com/example/loan/exception/ResultType.java
+++ b/src/main/java/com/example/loan/exception/ResultType.java
@@ -24,7 +24,11 @@ public enum ResultType {
 
     NOT_FOUND_CONTRACT("9000", "아직 계약이 체결되지 않았습니다."),
 
-    ALREADY_EXIST_BALANCE("9000", "해당 신청 건은 이미 집행되었습니다."),
+    ALREADY_EXIST_BALANCE("9000", "대출 잔고가 이미 존재합니다."),
+
+    NOT_FOUND_BALANCE("9000", "대출 잔고가 존재하지 않습니다."),
+
+    NOT_FOUND_ENTRY("9000", "집행 정보를 찾을 수 없습니다."),
 
     NOT_EXIST_FILE("4001", "파일이 존재하지 않습니다.");
 

--- a/src/main/java/com/example/loan/repository/EntryRepository.java
+++ b/src/main/java/com/example/loan/repository/EntryRepository.java
@@ -4,6 +4,10 @@ import com.example.loan.domain.Entry;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface EntryRepository extends JpaRepository<Entry, Long> {
+
+    Optional<Entry> findByApplicationId(Long applicationId);
 }

--- a/src/main/java/com/example/loan/service/BalanceService.java
+++ b/src/main/java/com/example/loan/service/BalanceService.java
@@ -5,4 +5,6 @@ import com.example.loan.dto.BalanceDTO;
 public interface BalanceService {
 
     BalanceDTO.Response create(Long applicationId, BalanceDTO.Request request);
+
+    BalanceDTO.Response update(Long applicationId, BalanceDTO.UpdateRequest request);
 }

--- a/src/main/java/com/example/loan/service/BalanceServiceImpl.java
+++ b/src/main/java/com/example/loan/service/BalanceServiceImpl.java
@@ -40,4 +40,27 @@ public class BalanceServiceImpl implements BalanceService {
 
         return modelMapper.map(saved, BalanceDTO.Response.class);
     }
+
+    /**
+     * 대출 잔고 수정 (집행 수정과 연결됨)
+     */
+    @Override
+    public BalanceDTO.Response update(Long applicationId,
+                                      BalanceDTO.UpdateRequest request) {
+        // 신청건에 해당하는 잔고 존재 여부 검증 (잔고가 존재하지 않는 경우, 에러 발생)
+        Balance balance = balanceRepository.findByApplicationId(applicationId)
+                .orElseThrow(() -> new BaseException(ResultType.NOT_FOUND_BALANCE));
+
+        // as-is -> to-be (balance entryAmount update)
+        BigDecimal beforeEntryAmount = request.getBeforeEntryAmount();
+        BigDecimal afterEntryAmount = request.getAfterEntryAmount();
+        BigDecimal updatedBalance = balance.getBalance();
+
+        updatedBalance = updatedBalance.subtract(beforeEntryAmount).add(afterEntryAmount);
+        balance.setBalance(updatedBalance);
+
+        Balance updated = balanceRepository.save(balance);
+
+        return modelMapper.map(updated, BalanceDTO.Response.class);
+    }
 }

--- a/src/main/java/com/example/loan/service/EntryService.java
+++ b/src/main/java/com/example/loan/service/EntryService.java
@@ -9,4 +9,6 @@ public interface EntryService {
     EntryDTO.Response getEntry(Long applicationId);
 
     EntryDTO.UpdateResponse updateEntry(Long entryId, EntryDTO.Request request);
+
+    void deleteEntry(Long entryId);
 }

--- a/src/main/java/com/example/loan/service/EntryService.java
+++ b/src/main/java/com/example/loan/service/EntryService.java
@@ -5,4 +5,6 @@ import com.example.loan.dto.EntryDTO;
 public interface EntryService {
 
     EntryDTO.Response create(Long applicationId, EntryDTO.Request request);
+
+    EntryDTO.Response getEntry(Long applicationId);
 }

--- a/src/main/java/com/example/loan/service/EntryService.java
+++ b/src/main/java/com/example/loan/service/EntryService.java
@@ -7,4 +7,6 @@ public interface EntryService {
     EntryDTO.Response create(Long applicationId, EntryDTO.Request request);
 
     EntryDTO.Response getEntry(Long applicationId);
+
+    EntryDTO.UpdateResponse updateEntry(Long entryId, EntryDTO.Request request);
 }

--- a/src/main/java/com/example/loan/service/EntryServiceImpl.java
+++ b/src/main/java/com/example/loan/service/EntryServiceImpl.java
@@ -52,6 +52,17 @@ public class EntryServiceImpl implements EntryService {
     }
 
     /**
+     * 대출 집행 조회 - (대출 신청 아이디 기준으로 조회)
+     */
+    @Override
+    public EntryDTO.Response getEntry(Long applicationId) {
+        Entry entry = entryRepository.findByApplicationId(applicationId)
+                .orElseThrow(() -> new BaseException(ResultType.SYSTEM_ERROR));
+
+        return modelMapper.map(entry, EntryDTO.Response.class);
+    }
+
+    /**
      * 유효성 검증 메서드
      */
     private boolean isContractedApplication(Long applicationId) {

--- a/src/main/java/com/example/loan/service/EntryServiceImpl.java
+++ b/src/main/java/com/example/loan/service/EntryServiceImpl.java
@@ -99,6 +99,29 @@ public class EntryServiceImpl implements EntryService {
     }
 
     /**
+     * 대출 집행 삭제
+     */
+    @Override
+    public void deleteEntry(Long entryId) {
+        // 집행 정보 존재 여부 검증
+        Entry entry = entryRepository.findById(entryId)
+                .orElseThrow(() -> new BaseException(ResultType.NOT_FOUND_ENTRY));
+
+        entry.setIsDeleted(true);
+
+        entryRepository.save(entry);
+
+        // 대출 잔고 수정
+        Long applicationId = entry.getApplicationId();
+        balanceService.update(applicationId,
+                BalanceDTO.UpdateRequest.builder()
+                        .applicationId(applicationId)
+                        .beforeEntryAmount(entry.getEntryAmount())
+                        .afterEntryAmount(BigDecimal.ZERO)
+                        .build());
+    }
+
+    /**
      * 유효성 검증 메서드
      */
     private boolean isContractedApplication(Long applicationId) {


### PR DESCRIPTION
## 작업 내용 (Contents)
<!-- 이 PR에서 어떤 점들이 변경되었는지 기술해주세요.-->
**1. 대출 집행 정보 조회**
- 대출 신청건에 해당하는 집행 정보가 존재하지 않는 경우 에러 발생시킴

**2. 대출 집행 정보 수정**
- 집행 금액과 변경 후 집행 금액을 요청받기 위해 BalanceDTO 에 UpdateRequest를 추가 생성
- 변경 전 집행 금액과 변경 후 집행 금액을 반환하기 위해 추가로 EntryDTO 에 UpdateResponse 생성
- 집행 정보 존재 여부 검증을 해 존재하지 않는 경우 에러 발생시킴
- 집행 정보가 수정되는 시점에 잔고를 업데이트하는 기능을 새로 추가함

**3. 대출 집행 정보 삭제**
- 집행 정보가 삭제되는 시점에 balance 도 0원으로 변경하도록 구현

**4. balanceService 대출 잔고 생성 기능 코드 개선**
- 현재 대출 잔고 생성 로직은 대출 신청 건에 해당하는 잔고가 존재하면 에러를 발생시키도록 구현되어 있음
- 만약, 대출 집행 정보를 삭제 후, 다음에 해당 대출 신청 건에 대출 집행을 등록하게 되면 0으로 남은 잔고가 존재하여 에러를 발생하게 됨
- 따라서, 대출 잔고를 생성할 때 기존 잔고가 존재하는 경우에는 에러를 뱉는 게 아닌 기존 잔고의 정보를 balance 객체에 넣어주도록 개선함


<br>

## 기타 사항 (Etc)
<!-- PR 에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등 -->
- 

<br>

## 테스트 (Test)
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요. -->

